### PR TITLE
Fix VarInt decoding with extra bytes at the end

### DIFF
--- a/src/varint.rs
+++ b/src/varint.rs
@@ -116,23 +116,23 @@ impl VarInt for u64 {
         let mut result: u64 = 0;
         let mut shift = 0;
 
-        if let Some(b) = src.last() {
-            if b & MSB != 0 {
-                return None;
-            }
-        }
-
+        let mut success = false;
         for b in src.iter() {
             let msb_dropped = b & DROP_MSB;
             result |= (msb_dropped as u64) << shift;
             shift += 7;
 
-            if b & MSB == 0 || shift > (10 * 7) {
+            if b & MSB == 0 || shift > (9 * 7) {
+                success = b & MSB == 0;
                 break;
             }
         }
 
-        Some((result, shift / 7 as usize))
+        if success {
+            Some((result, shift / 7 as usize))
+        } else {
+            None
+        }
     }
 
     #[inline]
@@ -161,23 +161,23 @@ impl VarInt for i64 {
         let mut result: u64 = 0;
         let mut shift = 0;
 
-        if let Some(b) = src.last() {
-            if b & MSB != 0 {
-                return None;
-            }
-        }
-
+        let mut success = false;
         for b in src.iter() {
             let msb_dropped = b & DROP_MSB;
             result |= (msb_dropped as u64) << shift;
             shift += 7;
 
-            if b & MSB == 0 || shift > (10 * 7) {
+            if b & MSB == 0 || shift > (9 * 7) {
+                success = b & MSB == 0;
                 break;
             }
         }
 
-        Some((zigzag_decode(result) as Self, shift / 7 as usize))
+        if success {
+            Some((zigzag_decode(result) as Self, shift / 7 as usize))
+        } else {
+            None
+        }
     }
 
     #[inline]

--- a/src/varint_tests.rs
+++ b/src/varint_tests.rs
@@ -166,4 +166,38 @@ mod tests {
         let mut read = &buf[..];
         assert!(read.read_varint::<u64>().is_err());
     }
+
+    #[test]
+    fn test_decode_extra_bytes_u64() {
+        let mut encoded = 0x12345u64.encode_var_vec();
+        assert_eq!(u64::decode_var(&encoded[..]), Some((0x12345, 3)));
+
+        encoded.push(0x99);
+        assert_eq!(u64::decode_var(&encoded[..]), Some((0x12345, 3)));
+
+        let encoded = [0xFF, 0xFF, 0xFF];
+        assert_eq!(u64::decode_var(&encoded[..]), None);
+
+        // Overflow
+        let mut encoded = vec![0xFF; 64];
+        encoded.push(0x00);
+        assert_eq!(u64::decode_var(&encoded[..]), None);
+    }
+
+    #[test]
+    fn test_decode_extra_bytes_i64() {
+        let mut encoded = (-0x12345i64).encode_var_vec();
+        assert_eq!(i64::decode_var(&encoded[..]), Some((-0x12345, 3)));
+
+        encoded.push(0x99);
+        assert_eq!(i64::decode_var(&encoded[..]), Some((-0x12345, 3)));
+
+        let encoded = [0xFF, 0xFF, 0xFF];
+        assert_eq!(i64::decode_var(&encoded[..]), None);
+
+        // Overflow
+        let mut encoded = vec![0xFF; 64];
+        encoded.push(0x00);
+        assert_eq!(i64::decode_var(&encoded[..]), None);
+    }
 }


### PR DESCRIPTION
After #10, decoding a VarInt from a slice can fail if the final byte of the slice has its MSB set, even if the VarInt decoding will never make it that far. This is an issue if we're decoding from a larger slice that has other encoded data after the VarInt.

It's not enough to check the last byte of the slice for the MSB being set -- we have to scan all the bytes and try to decode them, and only fail decoding if we never saw the MSB set in any byte.