### PR TITLE
Specify the license field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Lewin Bormann <lbo@spheniscida.de>"]
 description = "varint+zigzag and fixedint integer encoding/decoding (https://developers.google.com/protocol-buffers/docs/encoding)"
 repository = "https://github.com/dermesser/integer-encoding-rs"
 documentation = "https://docs.rs/integer-encoding/"
-license-file = "LICENSE"
+license = "MIT"
 keywords = ["integer", "varint", "zigzag", "protobuf", "serialize"]
 edition = "2018"
 


### PR DESCRIPTION
This is to facilitate the use of this crate in places that automatically
check the license field in Cargo.toml, such as Amazon's build system.