### PR TITLE
Replace unaligned pointer deref with read_unaligned

### DIFF
--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -54,7 +54,7 @@ macro_rules! impl_fixedint {
             }
             fn decode_fixed(src: &[u8]) -> $t {
                 assert_eq!(src.len(), Self::REQUIRED_SPACE);
-                return unsafe { *(src.as_ptr() as *const $t) };
+                return unsafe { (src.as_ptr() as *const $t).read_unaligned() };
             }
         }
     };


### PR DESCRIPTION
To deference a pointer, it must be correctly aligned for `T`. Since there's no alignment check at runtime or enforcement by the type system, this code must use `read_unaligned` to read the integer's bytes out of the slice. Code like this tends to work fine on x86 because it generally supports unaligned memory access, but may fault on other architectures.

This problem can be demonstrated by running `cargo miri test` before this PR.