### PR TITLE
Impl FixedInt for i8/u8 and fix size for isize/usize

### DIFF
--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -1,4 +1,4 @@
-use std::mem::transmute;
+use std::mem::{size_of, transmute};
 
 /// `FixedInt` provides encoding/decoding to and from fixed int representations.
 ///
@@ -8,7 +8,7 @@ pub trait FixedInt: Sized + Copy {
     /// Returns how many bytes are required to represent the given type.
     fn required_space() -> usize;
     /// Encode a value into the given slice. `dst` must be exactly `REQUIRED_SPACE` bytes.
-    fn encode_fixed(self, src: &mut [u8]);
+    fn encode_fixed(self, dst: &mut [u8]);
     /// Decode a value from the given slice. `src` must be exactly `REQUIRED_SPACE` bytes.
     fn decode_fixed(src: &[u8]) -> Self;
     /// Perform a transmute, i.e. return a "view" into the integer's memory, which is faster than
@@ -30,9 +30,9 @@ pub trait FixedInt: Sized + Copy {
 }
 
 macro_rules! impl_fixedint {
-    ($t:ty, $sz:expr) => {
+    ($t:ty) => {
         impl FixedInt for $t {
-            const REQUIRED_SPACE: usize = $sz;
+            const REQUIRED_SPACE: usize = size_of::<Self>();
 
             fn required_space() -> usize {
                 Self::REQUIRED_SPACE
@@ -51,10 +51,11 @@ macro_rules! impl_fixedint {
                 assert_eq!(dst.len(), Self::REQUIRED_SPACE);
 
                 #[allow(unused_mut)]
-                let mut encoded = unsafe { &*(&self as *const $t as *const [u8; $sz]) };
+                let mut encoded =
+                    unsafe { &*(&self as *const $t as *const [u8; Self::REQUIRED_SPACE]) };
 
                 #[cfg(target_endian = "big")]
-                {
+                if Self::REQUIRED_SPACE > 1 {
                     let mut encoded_rev = [0 as u8; Self::REQUIRED_SPACE];
                     encoded_rev.copy_from_slice(encoded);
                     encoded_rev.reverse();
@@ -65,31 +66,34 @@ macro_rules! impl_fixedint {
                 dst.clone_from_slice(encoded);
             }
 
+            #[cfg(target_endian = "little")]
             fn decode_fixed(src: &[u8]) -> $t {
-                assert_eq!(src.len(), Self::REQUIRED_SPACE);
-                #[cfg(target_endian = "little")]
-                let src_fin = src;
+                unsafe { (src.as_ptr() as *const $t).read_unaligned() }
+            }
 
-                #[cfg(target_endian = "big")]
-                let mut src_fin = [0 as u8; Self::REQUIRED_SPACE];
-
-                #[cfg(target_endian = "big")]
-                {
-                    src_fin.copy_from_slice(src);
-                    src_fin.reverse();
+            #[cfg(target_endian = "big")]
+            fn decode_fixed(src: &[u8]) -> $t {
+                match Self::REQUIRED_SPACE {
+                    1 => unsafe { (src.as_ptr() as *const $t).read_unaligned() },
+                    _ => {
+                        let mut src_fin = [0 as u8; Self::REQUIRED_SPACE];
+                        src_fin.copy_from_slice(src);
+                        src_fin.reverse();
+                        unsafe { (src_fin.as_ptr() as *const $t).read_unaligned() }
+                    }
                 }
-
-                return unsafe { (src_fin.as_ptr() as *const $t).read_unaligned() };
             }
         }
     };
 }
 
-impl_fixedint!(usize, 8);
-impl_fixedint!(u64, 8);
-impl_fixedint!(u32, 4);
-impl_fixedint!(u16, 2);
-impl_fixedint!(isize, 8);
-impl_fixedint!(i64, 8);
-impl_fixedint!(i32, 4);
-impl_fixedint!(i16, 2);
+impl_fixedint!(usize);
+impl_fixedint!(u64);
+impl_fixedint!(u32);
+impl_fixedint!(u16);
+impl_fixedint!(u8);
+impl_fixedint!(isize);
+impl_fixedint!(i64);
+impl_fixedint!(i32);
+impl_fixedint!(i16);
+impl_fixedint!(i8);

--- a/src/fixed_tests.rs
+++ b/src/fixed_tests.rs
@@ -21,6 +21,16 @@ mod tests {
         assert_eq!(result, vec![0, 1]);
     }
     #[test]
+    fn test_u8_enc() {
+        let result = (255 as u8).encode_fixed_vec();
+        assert_eq!(result, vec![255]);
+    }
+    #[test]
+    fn test_i8_enc() {
+        let result = (-1 as i8).encode_fixed_vec();
+        assert_eq!(result, vec![255]);
+    }
+    #[test]
     fn test_i16_enc() {
         let result = (-32768 as i16).encode_fixed_vec();
         assert_eq!(result, vec![0, 128]);
@@ -49,12 +59,14 @@ mod tests {
     }
     #[test]
     fn test_all_identity() {
-        let a: u16 = 17;
-        let b: u32 = 17;
-        let c: u64 = 17;
-        let d: i16 = -17;
-        let e: i32 = -17;
-        let f: i64 = -17;
+        let a: u8 = 17;
+        let b: u16 = 17;
+        let c: u32 = 17;
+        let d: u64 = 17;
+        let e: i8 = -17;
+        let f: i16 = -17;
+        let g: i32 = -17;
+        let h: i64 = -17;
 
         assert_eq!(a, FixedInt::decode_fixed_vec(&a.encode_fixed_vec()));
         assert_eq!(b, FixedInt::decode_fixed_vec(&b.encode_fixed_vec()));
@@ -62,6 +74,8 @@ mod tests {
         assert_eq!(d, FixedInt::decode_fixed_vec(&d.encode_fixed_vec()));
         assert_eq!(e, FixedInt::decode_fixed_vec(&e.encode_fixed_vec()));
         assert_eq!(f, FixedInt::decode_fixed_vec(&f.encode_fixed_vec()));
+        assert_eq!(g, FixedInt::decode_fixed_vec(&g.encode_fixed_vec()));
+        assert_eq!(h, FixedInt::decode_fixed_vec(&h.encode_fixed_vec()));
 
         assert_eq!(a, FixedInt::decode_fixed(&a.encode_fixed_light()));
         assert_eq!(b, FixedInt::decode_fixed(&b.encode_fixed_light()));
@@ -69,6 +83,8 @@ mod tests {
         assert_eq!(d, FixedInt::decode_fixed(&d.encode_fixed_light()));
         assert_eq!(e, FixedInt::decode_fixed(&e.encode_fixed_light()));
         assert_eq!(f, FixedInt::decode_fixed(&f.encode_fixed_light()));
+        assert_eq!(g, FixedInt::decode_fixed(&g.encode_fixed_light()));
+        assert_eq!(h, FixedInt::decode_fixed(&h.encode_fixed_light()));
     }
 
     #[test]
@@ -120,12 +136,16 @@ mod tests {
         let i3: u32 = 4200123456;
         let i4: i64 = i3 as i64 * 1000;
         let i5: i32 = -32456;
+        let i6: i8 = -128;
+        let i7: u8 = 255;
 
         buf.write_fixedint_async(i1).await.unwrap();
         buf.write_fixedint_async(i2).await.unwrap();
         buf.write_fixedint_async(i3).await.unwrap();
         buf.write_fixedint_async(i4).await.unwrap();
         buf.write_fixedint_async(i5).await.unwrap();
+        buf.write_fixedint_async(i6).await.unwrap();
+        buf.write_fixedint_async(i7).await.unwrap();
 
         let mut reader: &[u8] = buf.as_ref();
 
@@ -134,6 +154,8 @@ mod tests {
         assert_eq!(i3, reader.read_fixedint_async().await.unwrap());
         assert_eq!(i4, reader.read_fixedint_async().await.unwrap());
         assert_eq!(i5, reader.read_fixedint_async().await.unwrap());
+        assert_eq!(i6, reader.read_fixedint_async().await.unwrap());
+        assert_eq!(i7, reader.read_fixedint_async().await.unwrap());
         assert!(reader.read_fixedint_async::<u32>().await.is_err());
     }
 }

--- a/src/varint_tests.rs
+++ b/src/varint_tests.rs
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_regression_22() {
-        let mut encoded: Vec<u8> = (0x112233 as u64).encode_var_vec();
+        let encoded: Vec<u8> = (0x112233 as u64).encode_var_vec();
         assert_eq!(
             encoded.as_slice().read_varint::<i8>().unwrap_err().kind(),
             std::io::ErrorKind::InvalidData


### PR DESCRIPTION
1. Added`Impl FixedInt` for `i8` and `u8`, which could make some users' code (including mime) more consistent. I avoided endian converion on `i8`/`u8`, thinking this should bring a better performance.
2. Removed the size parameter `sz` from the macro `impl_fixedint`, use `std::mem::size_of` to obtain the size. The size of `isize`/`usize` may not be `8` on some platform, operating raw memory on with incorrect length should cause unpredictable behavior (if I've got it right).

This is my first public PR on Github, and I'm still new to Rust language, so please let me know if something is incorrect.