### PR TITLE
Draft backward incompatible: proposal to address UB `FixedInt`

### DIFF
--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -32,9 +32,15 @@ pub trait FixedInt: Sized + Copy {
     /// on big-endian machines). If you receive a big-endian integer, and would like it to be
     /// treated correctly, use this helper method to convert between endiannesses.
     fn switch_endianness(self) -> Self {
+        // an implementation of `FixedInt` may not provide the correct space,
+        // resulting in UB.
+        assert_eq!(size_of::<Self>(), Self::REQUIRED_SPACE);
         // Switch to intrinsic bswap when out of nightly.
         unsafe {
-            let sl = std::slice::from_raw_parts_mut(transmute::<&Self, *mut u8>(&self), Self::REQUIRED_SPACE);
+            let sl = std::slice::from_raw_parts_mut(
+                transmute::<&Self, *mut u8>(&self),
+                Self::REQUIRED_SPACE,
+            );
             sl.reverse();
             *transmute::<*const u8, &Self>(sl.as_ptr())
         }

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -1,105 +1,62 @@
-use std::mem::{size_of, transmute};
+use std::convert::TryInto;
+use std::mem::size_of;
 
 /// `FixedInt` provides encoding/decoding to and from fixed int representations.
 ///
 /// The emitted bytestring contains the bytes of the integer in machine endianness.
 pub trait FixedInt: Sized + Copy {
-    const REQUIRED_SPACE: usize;
-    /// Returns how many bytes are required to represent the given type.
-    fn required_space() -> usize;
+    type Bytes: AsRef<[u8]>;
+
     /// Encode a value into the given slice. `dst` must be exactly `REQUIRED_SPACE` bytes.
     fn encode_fixed(self, dst: &mut [u8]);
     /// Decode a value from the given slice. `src` must be exactly `REQUIRED_SPACE` bytes.
     fn decode_fixed(src: &[u8]) -> Self;
-    /// Perform a transmute, i.e. return a "view" into the integer's memory, which is faster than
-    /// performing a copy.
-    fn encode_fixed_light<'a>(&'a self) -> &'a [u8];
+    /// Returns the representation of [`FixedInt`] as [`Bytes`], the little-endian representation
+    /// of self in the stack.
+    fn encode_fixed_light(self) -> Self::Bytes;
 
     /// Helper: Encode the value and return a Vec.
     fn encode_fixed_vec(self) -> Vec<u8> {
-        let mut v = Vec::new();
-        v.resize(Self::required_space(), 0);
-        self.encode_fixed(&mut v[..]);
-        v
+        self.encode_fixed_light().as_ref().to_vec()
     }
+
     /// Helper: Decode the value from the Vec.
     fn decode_fixed_vec(v: &Vec<u8>) -> Self {
-        assert_eq!(v.len(), Self::required_space());
         Self::decode_fixed(&v[..])
     }
 
     /// integer-encoding-rs always emits and receives little-endian integers (converting implicitly
     /// on big-endian machines). If you receive a big-endian integer, and would like it to be
     /// treated correctly, use this helper method to convert between endiannesses.
-    fn switch_endianness(self) -> Self {
-        // an implementation of `FixedInt` may not provide the correct space,
-        // resulting in UB.
-        assert_eq!(size_of::<Self>(), Self::REQUIRED_SPACE);
-        // Switch to intrinsic bswap when out of nightly.
-        unsafe {
-            let sl = std::slice::from_raw_parts_mut(
-                transmute::<&Self, *mut u8>(&self),
-                Self::REQUIRED_SPACE,
-            );
-            sl.reverse();
-            *transmute::<*const u8, &Self>(sl.as_ptr())
-        }
-    }
+    fn switch_endianness(self) -> Self;
 }
 
 macro_rules! impl_fixedint {
     ($t:ty) => {
         impl FixedInt for $t {
-            const REQUIRED_SPACE: usize = size_of::<Self>();
+            type Bytes = [u8; size_of::<$t>()];
 
-            fn required_space() -> usize {
-                Self::REQUIRED_SPACE
-            }
-
-            fn encode_fixed_light<'a>(&'a self) -> &'a [u8] {
-                return unsafe {
-                    std::slice::from_raw_parts(
-                        transmute::<&$t, *const u8>(&self),
-                        Self::REQUIRED_SPACE,
-                    )
-                };
+            fn encode_fixed_light(self) -> Self::Bytes {
+                self.to_le_bytes()
             }
 
             fn encode_fixed(self, dst: &mut [u8]) {
-                assert_eq!(dst.len(), Self::REQUIRED_SPACE);
-
-                #[allow(unused_mut)]
-                let mut encoded =
-                    unsafe { &*(&self as *const $t as *const [u8; Self::REQUIRED_SPACE]) };
-
-                #[cfg(target_endian = "big")]
-                if Self::REQUIRED_SPACE > 1 {
-                    let mut encoded_rev = [0 as u8; Self::REQUIRED_SPACE];
-                    encoded_rev.copy_from_slice(encoded);
-                    encoded_rev.reverse();
-                    dst.clone_from_slice(&encoded_rev);
-                    return;
-                }
-
-                dst.clone_from_slice(encoded);
+                assert_eq!(dst.len(), size_of::<Self>());
+                dst.clone_from_slice(&self.to_le_bytes());
             }
 
             #[cfg(target_endian = "little")]
-            fn decode_fixed(src: &[u8]) -> $t {
-                unsafe { (src.as_ptr() as *const $t).read_unaligned() }
+            fn decode_fixed(src: &[u8]) -> Self {
+                Self::from_le_bytes(src.try_into().unwrap())
             }
 
             #[cfg(target_endian = "big")]
             fn decode_fixed(src: &[u8]) -> $t {
-                match Self::REQUIRED_SPACE {
-                    1 => unsafe { (src.as_ptr() as *const $t).read_unaligned() },
-                    _ => {
-                        let mut src_fin = [0 as u8; Self::REQUIRED_SPACE];
-                        src_fin.copy_from_slice(src);
-                        src_fin.reverse();
-                        unsafe { (src_fin.as_ptr() as *const $t).read_unaligned() }
-                    }
-                }
+                Self::from_be_bytes(src.try_into().unwrap())
+            }
+
+            fn switch_endianness(self) -> Self {
+                Self::from_le_bytes(self.to_be_bytes())
             }
         }
     };

--- a/src/fixed_tests.rs
+++ b/src/fixed_tests.rs
@@ -75,38 +75,11 @@ mod tests {
     }
     */
 
-    #[should_panic]
-    #[test]
-    fn test_switch() {
-        impl FixedInt for i128 {
-            const REQUIRED_SPACE: usize = 256;
-
-            fn required_space() -> usize {
-                todo!()
-            }
-
-            fn encode_fixed(self, dst: &mut [u8]) {
-                todo!()
-            }
-
-            fn decode_fixed(src: &[u8]) -> Self {
-                todo!()
-            }
-
-            fn encode_fixed_light<'a>(&'a self) -> &'a [u8] {
-                todo!()
-            }
-        }
-
-        let int = -32767i128;
-        let int = int.switch_endianness();
-    }
-
     #[test]
     fn test_i32_enc_light() {
         let int = -32767 as i32;
         let result = int.encode_fixed_light();
-        assert_eq!(result, &[1, 128, 255, 255]);
+        assert_eq!(result, [1, 128, 255, 255]);
     }
     #[test]
     fn test_all_identity() {

--- a/src/fixed_tests.rs
+++ b/src/fixed_tests.rs
@@ -75,6 +75,33 @@ mod tests {
     }
     */
 
+    #[should_panic]
+    #[test]
+    fn test_switch() {
+        impl FixedInt for i128 {
+            const REQUIRED_SPACE: usize = 256;
+
+            fn required_space() -> usize {
+                todo!()
+            }
+
+            fn encode_fixed(self, dst: &mut [u8]) {
+                todo!()
+            }
+
+            fn decode_fixed(src: &[u8]) -> Self {
+                todo!()
+            }
+
+            fn encode_fixed_light<'a>(&'a self) -> &'a [u8] {
+                todo!()
+            }
+        }
+
+        let int = -32767i128;
+        let int = int.switch_endianness();
+    }
+
     #[test]
     fn test_i32_enc_light() {
         let int = -32767 as i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! fn main() {
 //!     let a: u32 = 344;
 //!     let encoded_byte_slice = a.encode_fixed_light();
-//!     assert_eq!(a, u32::decode_fixed(encoded_byte_slice));
+//!     assert_eq!(a, u32::decode_fixed(&encoded_byte_slice));
 //!     assert_eq!(4, encoded_byte_slice.len());
 //!
 //!     let b: i32 = -111;
@@ -22,7 +22,7 @@
 //!     assert_eq!(Some((b, 2)), i32::decode_var(&encoded_byte_vec));
 //! }
 //! ```
-
+#[forbid(unsafe_code)]
 mod fixed;
 mod fixed_tests;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -134,15 +134,16 @@ pub trait FixedIntAsyncReader {
 impl<AR: AsyncRead + Unpin + Send> FixedIntAsyncReader for AR {
     async fn read_fixedint_async<FI: FixedInt>(&mut self) -> Result<FI> {
         let mut buf = [0 as u8; 8];
-        self.read_exact(&mut buf[0..FI::required_space()]).await?;
-        Ok(FI::decode_fixed(&buf[0..FI::required_space()]))
+        self.read_exact(&mut buf[0..std::mem::size_of::<FI>()])
+            .await?;
+        Ok(FI::decode_fixed(&buf[0..std::mem::size_of::<FI>()]))
     }
 }
 
 impl<R: Read> FixedIntReader for R {
     fn read_fixedint<FI: FixedInt>(&mut self) -> Result<FI> {
         let mut buf = [0 as u8; 8];
-        self.read_exact(&mut buf[0..FI::required_space()])?;
-        Ok(FI::decode_fixed(&buf[0..FI::required_space()]))
+        self.read_exact(&mut buf[0..std::mem::size_of::<FI>()])?;
+        Ok(FI::decode_fixed(&buf[0..std::mem::size_of::<FI>()]))
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -60,18 +60,18 @@ pub trait FixedIntAsyncWriter {
 impl<AW: AsyncWrite + Unpin + Send> FixedIntAsyncWriter for AW {
     async fn write_fixedint_async<FI: FixedInt + Send>(&mut self, n: FI) -> Result<usize> {
         let mut buf = [0 as u8; 8];
-        n.encode_fixed(&mut buf[0..FI::required_space()]);
-        self.write_all(&buf[0..FI::required_space()]).await?;
-        Ok(FI::REQUIRED_SPACE)
+        n.encode_fixed(&mut buf[..std::mem::size_of::<FI>()]);
+        self.write_all(&buf[..std::mem::size_of::<FI>()]).await?;
+        Ok(std::mem::size_of::<FI>())
     }
 }
 
 impl<W: Write> FixedIntWriter for W {
     fn write_fixedint<FI: FixedInt>(&mut self, n: FI) -> Result<usize> {
         let mut buf = [0 as u8; 8];
-        n.encode_fixed(&mut buf[0..FI::required_space()]);
+        n.encode_fixed(&mut buf[..std::mem::size_of::<FI>()]);
 
-        self.write_all(&buf[0..FI::required_space()])?;
-        Ok(FI::REQUIRED_SPACE)
+        self.write_all(&buf[..std::mem::size_of::<FI>()])?;
+        Ok(std::mem::size_of::<FI>())
     }
 }


### PR DESCRIPTION
* Remove `FixedInt::REQUIRED_SPACE`
* Added `FixedInt::Bytes`
* Remove `fn required_space`
* Made `switch_endianness` implementation required
* Add `forbid(unsafe_code)`
