### PR TITLE
feat: remove not required `Send` bound

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -25,7 +25,7 @@ pub trait VarIntReader {
 
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
 /// Like a VarIntReader, but returns a future.
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait VarIntAsyncReader {
     async fn read_varint_async<VI: VarInt>(&mut self) -> Result<VI>;
 }
@@ -65,8 +65,8 @@ impl VarIntProcessor {
 }
 
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
-#[async_trait::async_trait]
-impl<AR: AsyncRead + Unpin + Send> VarIntAsyncReader for AR {
+#[async_trait::async_trait(?Send)]
+impl<AR: AsyncRead + Unpin> VarIntAsyncReader for AR {
     async fn read_varint_async<VI: VarInt>(&mut self) -> Result<VI> {
         let mut buf = [0 as u8; 1];
         let mut p = VarIntProcessor::new::<VI>();
@@ -124,14 +124,14 @@ pub trait FixedIntReader {
 
 /// Like FixedIntReader, but returns a future.
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait FixedIntAsyncReader {
     async fn read_fixedint_async<FI: FixedInt>(&mut self) -> Result<FI>;
 }
 
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
-#[async_trait::async_trait]
-impl<AR: AsyncRead + Unpin + Send> FixedIntAsyncReader for AR {
+#[async_trait::async_trait(?Send)]
+impl<AR: AsyncRead + Unpin> FixedIntAsyncReader for AR {
     async fn read_fixedint_async<FI: FixedInt>(&mut self) -> Result<FI> {
         let mut buf = [0 as u8; 8];
         self.read_exact(&mut buf[0..std::mem::size_of::<FI>()])

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -17,16 +17,16 @@ pub trait VarIntWriter {
 
 /// Like VarIntWriter, but asynchronous.
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait VarIntAsyncWriter {
     /// Write a VarInt integer to an asynchronous writer.
-    async fn write_varint_async<VI: VarInt + Send>(&mut self, n: VI) -> Result<usize>;
+    async fn write_varint_async<VI: VarInt>(&mut self, n: VI) -> Result<usize>;
 }
 
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
-#[async_trait::async_trait]
-impl<AW: AsyncWrite + Send + Unpin> VarIntAsyncWriter for AW {
-    async fn write_varint_async<VI: VarInt + Send>(&mut self, n: VI) -> Result<usize> {
+#[async_trait::async_trait(?Send)]
+impl<AW: AsyncWrite + Unpin> VarIntAsyncWriter for AW {
+    async fn write_varint_async<VI: VarInt>(&mut self, n: VI) -> Result<usize> {
         let mut buf = [0 as u8; 10];
         let b = n.encode_var(&mut buf);
         self.write_all(&buf[0..b]).await?;
@@ -50,15 +50,15 @@ pub trait FixedIntWriter {
 }
 
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait FixedIntAsyncWriter {
-    async fn write_fixedint_async<FI: FixedInt + Send>(&mut self, n: FI) -> Result<usize>;
+    async fn write_fixedint_async<FI: FixedInt>(&mut self, n: FI) -> Result<usize>;
 }
 
 #[cfg(any(feature = "tokio_async", feature = "futures_async"))]
-#[async_trait::async_trait]
-impl<AW: AsyncWrite + Unpin + Send> FixedIntAsyncWriter for AW {
-    async fn write_fixedint_async<FI: FixedInt + Send>(&mut self, n: FI) -> Result<usize> {
+#[async_trait::async_trait(?Send)]
+impl<AW: AsyncWrite + Unpin> FixedIntAsyncWriter for AW {
+    async fn write_fixedint_async<FI: FixedInt>(&mut self, n: FI) -> Result<usize> {
         let mut buf = [0 as u8; 8];
         n.encode_fixed(&mut buf[..std::mem::size_of::<FI>()]);
         self.write_all(&buf[..std::mem::size_of::<FI>()]).await?;


### PR DESCRIPTION
The async traits don't actually require the use of the `Send` bound. This is required for us to make use of them in a wasm context, where we explicitly have `!Send` readers and writers.