### PR TITLE
fix: decode now returns `None` with u64::MAX + 1

### DIFF
--- a/src/varint.rs
+++ b/src/varint.rs
@@ -140,8 +140,11 @@ impl VarInt for u64 {
             result |= (msb_dropped as u64) << shift;
             shift += 7;
 
-            if b & MSB == 0 || shift > (9 * 7) {
-                success = b & MSB == 0;
+            if shift > (9 * 7) {
+                success = *b == 1;
+                break;
+            } else if b & MSB == 0 {
+                success = true;
                 break;
             }
         }

--- a/src/varint_tests.rs
+++ b/src/varint_tests.rs
@@ -51,6 +51,12 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_max_u64_plus_one() {
+        let max_vec_encoded = vec![0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        assert!(u64::decode_var(max_vec_encoded.as_slice()).is_none());
+    }
+
+    #[test]
     fn test_encode_i64() {
         assert_eq!((0 as i64).encode_var_vec(), (0 as u32).encode_var_vec());
         assert_eq!((150 as i64).encode_var_vec(), (300 as u32).encode_var_vec());


### PR DESCRIPTION
# Rationale

`[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02]` is the encoding of `u64::MAX`.
This does not return `None` when decoding even though it should.

This PR fixes this issue.

# Changes

* `u64::decode_var` now returns `None` when a 10th byte is used but is more than `1`.
* A test is added for the above case.